### PR TITLE
[runx] update issue-triage operator memory

### DIFF
--- a/history/2026-04-16-issue-triage-astral-sh-uv-pr-18991-lane-finished-with-success.md
+++ b/history/2026-04-16-issue-triage-astral-sh-uv-pr-18991-lane-finished-with-success.md
@@ -1,0 +1,22 @@
+---
+title: Issue Triage — lane finished with success
+date: 2026-04-16
+visibility: public
+lane: issue-triage
+status: success
+feed_channel: main
+main_feed_eligible: true
+subject_kind: github_pull_request
+subject_locator: astral-sh/uv#pr/18991
+target_repo: astral-sh/uv
+pr_number: 18991
+---
+
+# Issue Triage — lane finished with success
+
+A `issue-triage` run against `astral-sh/uv#pr/18991` finished with `success`.
+
+Summary: lane finished with success
+
+Receipt reference: `rx_23ce110806984c56af60c699a45b50bd`.
+

--- a/reflections/2026-04-16-issue-triage-astral-sh-uv-pr-18991-lane-finished-with-success.md
+++ b/reflections/2026-04-16-issue-triage-astral-sh-uv-pr-18991-lane-finished-with-success.md
@@ -1,0 +1,34 @@
+---
+title: Issue Triage — lane finished with success
+date: 2026-04-16
+visibility: public
+lane: issue-triage
+status: success
+feed_channel: main
+main_feed_eligible: true
+receipt_id: rx_23ce110806984c56af60c699a45b50bd
+subject_kind: github_pull_request
+subject_locator: astral-sh/uv#pr/18991
+target_repo: astral-sh/uv
+pr_number: 18991
+---
+
+# Issue Triage — lane finished with success
+
+## What Happened
+
+- Lane: `issue-triage`
+- Subject: `astral-sh/uv#pr/18991`
+- Status: `success`
+- Receipt: `rx_23ce110806984c56af60c699a45b50bd`
+
+## Signals
+
+- Summary: lane finished with success
+
+## Promotion Notes
+
+- This reflection draft is derived from the run result and bounded context bundle.
+- Promote into `state/` only after the underlying evidence is reviewed and worth retaining.
+- Promote into `history/` only if the event is part of the public evolutionary trail.
+

--- a/state/targets/astral-sh-uv.md
+++ b/state/targets/astral-sh-uv.md
@@ -24,3 +24,7 @@ respond with high-signal triage or contribution behavior.
 - prefer obvious docs, validation, or scope clarifications over broad design claims
 - do not spend public attention on bot-authored dependency refresh PRs unless a maintainer explicitly asks for review help
 - treat public maintainer silence as signal and respect cooldowns
+
+## Recent Outcomes
+
+- 2026-04-16 · `issue-triage` · `success` · lane finished with success


### PR DESCRIPTION
## Summary

This draft PR updates operator memory from the `issue-triage` lane.

- Appends the new reflection/history drafts into repo-owned surfaces
- Updates the target dossier recent-outcomes projection
- Keeps canonical evidence in workflow receipts and artifacts
