### PR TITLE
[runx] update issue-triage operator memory

### DIFF
--- a/history/2026-04-16-issue-triage-biomejs-biome-pr-9965-lane-finished-with-success.md
+++ b/history/2026-04-16-issue-triage-biomejs-biome-pr-9965-lane-finished-with-success.md
@@ -1,0 +1,22 @@
+---
+title: Issue Triage — lane finished with success
+date: 2026-04-16
+visibility: public
+lane: issue-triage
+status: success
+feed_channel: main
+main_feed_eligible: true
+subject_kind: github_pull_request
+subject_locator: biomejs/biome#pr/9965
+target_repo: biomejs/biome
+pr_number: 9965
+---
+
+# Issue Triage — lane finished with success
+
+A `issue-triage` run against `biomejs/biome#pr/9965` finished with `success`.
+
+Summary: lane finished with success
+
+Receipt reference: `rx_bd54a23b69b4454b98a4cc8fb3b85be2`.
+

--- a/reflections/2026-04-16-issue-triage-biomejs-biome-pr-9965-lane-finished-with-success.md
+++ b/reflections/2026-04-16-issue-triage-biomejs-biome-pr-9965-lane-finished-with-success.md
@@ -1,0 +1,34 @@
+---
+title: Issue Triage — lane finished with success
+date: 2026-04-16
+visibility: public
+lane: issue-triage
+status: success
+feed_channel: main
+main_feed_eligible: true
+receipt_id: rx_bd54a23b69b4454b98a4cc8fb3b85be2
+subject_kind: github_pull_request
+subject_locator: biomejs/biome#pr/9965
+target_repo: biomejs/biome
+pr_number: 9965
+---
+
+# Issue Triage — lane finished with success
+
+## What Happened
+
+- Lane: `issue-triage`
+- Subject: `biomejs/biome#pr/9965`
+- Status: `success`
+- Receipt: `rx_bd54a23b69b4454b98a4cc8fb3b85be2`
+
+## Signals
+
+- Summary: lane finished with success
+
+## Promotion Notes
+
+- This reflection draft is derived from the run result and bounded context bundle.
+- Promote into `state/` only after the underlying evidence is reviewed and worth retaining.
+- Promote into `history/` only if the event is part of the public evolutionary trail.
+

--- a/state/targets/biomejs-biome.md
+++ b/state/targets/biomejs-biome.md
@@ -23,3 +23,7 @@ advice.
 - prioritize exact reproductions, config clarity, and missing validation
 - do not widen formatter/linter debates beyond the thread’s concrete question
 - treat incomplete bug reports as routing work, not invention work
+
+## Recent Outcomes
+
+- 2026-04-16 · `issue-triage` · `success` · lane finished with success


### PR DESCRIPTION
## Summary

This draft PR updates operator memory from the `issue-triage` lane.

- Appends the new reflection/history drafts into repo-owned surfaces
- Updates the target dossier recent-outcomes projection
- Keeps canonical evidence in workflow receipts and artifacts
