### PR TITLE
[runx] update issue-triage operator memory

### DIFF
--- a/history/2026-04-16-issue-triage-nilstate-automaton-pr-18-lane-finished-with-success.md
+++ b/history/2026-04-16-issue-triage-nilstate-automaton-pr-18-lane-finished-with-success.md
@@ -1,0 +1,22 @@
+---
+title: Issue Triage — lane finished with success
+date: 2026-04-16
+visibility: public
+lane: issue-triage
+status: success
+feed_channel: main
+main_feed_eligible: true
+subject_kind: github_pull_request
+subject_locator: nilstate/automaton#pr/18
+target_repo: nilstate/automaton
+pr_number: 18
+---
+
+# Issue Triage — lane finished with success
+
+A `issue-triage` run against `nilstate/automaton#pr/18` finished with `success`.
+
+Summary: lane finished with success
+
+Receipt reference: `rx_c2d20246cd3b4eb6a2f5905c3be636ad`.
+

--- a/reflections/2026-04-16-issue-triage-nilstate-automaton-pr-18-lane-finished-with-success.md
+++ b/reflections/2026-04-16-issue-triage-nilstate-automaton-pr-18-lane-finished-with-success.md
@@ -1,0 +1,34 @@
+---
+title: Issue Triage — lane finished with success
+date: 2026-04-16
+visibility: public
+lane: issue-triage
+status: success
+feed_channel: main
+main_feed_eligible: true
+receipt_id: rx_c2d20246cd3b4eb6a2f5905c3be636ad
+subject_kind: github_pull_request
+subject_locator: nilstate/automaton#pr/18
+target_repo: nilstate/automaton
+pr_number: 18
+---
+
+# Issue Triage — lane finished with success
+
+## What Happened
+
+- Lane: `issue-triage`
+- Subject: `nilstate/automaton#pr/18`
+- Status: `success`
+- Receipt: `rx_c2d20246cd3b4eb6a2f5905c3be636ad`
+
+## Signals
+
+- Summary: lane finished with success
+
+## Promotion Notes
+
+- This reflection draft is derived from the run result and bounded context bundle.
+- Promote into `state/` only after the underlying evidence is reviewed and worth retaining.
+- Promote into `history/` only if the event is part of the public evolutionary trail.
+

--- a/state/targets/nilstate-automaton.md
+++ b/state/targets/nilstate-automaton.md
@@ -27,3 +27,6 @@ line.
 - public narrative must remain subordinate to receipts and committed state
 - changes that alter workflow publication rules deserve extra care
 
+## Recent Outcomes
+
+- 2026-04-16 · `issue-triage` · `success` · lane finished with success


### PR DESCRIPTION
## Summary

This draft PR updates operator memory from the `issue-triage` lane.

- Appends the new reflection/history drafts into repo-owned surfaces
- Updates the target dossier recent-outcomes projection
- Keeps canonical evidence in workflow receipts and artifacts
