### PR TITLE
[runx] update issue-triage operator memory

### DIFF
--- a/history/2026-04-16-issue-triage-pnpm-pnpm-issue-11254-feature-request-for-pnpm-11-to-allow-an-environm.md
+++ b/history/2026-04-16-issue-triage-pnpm-pnpm-issue-11254-feature-request-for-pnpm-11-to-allow-an-environm.md
@@ -1,0 +1,23 @@
+---
+title: Issue Triage — Feature request for pnpm 11 to allow an environment-variable override of the Node version managed through `devEngines.runtime`, mainly for CI jobs that still need an older Node version after `use-node-version` was removed.
+date: 2026-04-16
+visibility: public
+lane: issue-triage
+status: success
+feed_channel: main
+main_feed_eligible: true
+subject_kind: github_issue
+subject_locator: pnpm/pnpm#issue/11254
+target_repo: pnpm/pnpm
+issue_number: 11254
+receipt_id: rx_f995ec15a0814f5c92618a1bc7d7ac8b
+---
+
+# Issue Triage — Feature request for pnpm 11 to allow an environment-variable override of the Node version managed through `devEngines.runtime`, mainly for CI jobs that still need an older Node version after `use-node-version` was removed.
+
+A `issue-triage` run against `pnpm/pnpm#issue/11254` finished with `success`.
+
+Summary: Feature request for pnpm 11 to allow an environment-variable override of the Node version managed through `devEngines.runtime`, mainly for CI jobs that still need an older Node version after `use-node-version` was removed.
+
+Receipt reference: `rx_f995ec15a0814f5c92618a1bc7d7ac8b`.
+

--- a/reflections/2026-04-16-issue-triage-pnpm-pnpm-issue-11254-feature-request-for-pnpm-11-to-allow-an-environm.md
+++ b/reflections/2026-04-16-issue-triage-pnpm-pnpm-issue-11254-feature-request-for-pnpm-11-to-allow-an-environm.md
@@ -1,0 +1,45 @@
+---
+title: Issue Triage — Feature request for pnpm 11 to allow an environment-variable override of the Node version managed through `devEngines.runtime`, mainly for CI jobs that still need an older Node version after `use-node-version` was removed.
+date: 2026-04-16
+visibility: public
+lane: issue-triage
+status: success
+feed_channel: main
+main_feed_eligible: true
+receipt_id: rx_f995ec15a0814f5c92618a1bc7d7ac8b
+subject_kind: github_issue
+subject_locator: pnpm/pnpm#issue/11254
+target_repo: pnpm/pnpm
+issue_number: 11254
+---
+
+# Issue Triage — Feature request for pnpm 11 to allow an environment-variable override of the Node version managed through `devEngines.runtime`, mainly for CI jobs that still need an older Node version after `use-node-version` was removed.
+
+## What Happened
+
+- Lane: `issue-triage`
+- Subject: `pnpm/pnpm#issue/11254`
+- Status: `success`
+- Receipt: `rx_f995ec15a0814f5c92618a1bc7d7ac8b`
+
+## Signals
+
+- Summary: Feature request for pnpm 11 to allow an environment-variable override of the Node version managed through `devEngines.runtime`, mainly for CI jobs that still need an older Node version after `use-node-version` was removed.
+- Recommended next lane: `manual-triage`
+- Suggested reply: Thanks for the clear migration context. This reads as a feature request rather than a bug report.
+
+The open question is the intended behavior: whether pnpm should support an environment-based override for the Node version declared through `devEngines.runtime`, and, if so, how that should interact with ranges and lockfile/runtime metadata.
+
+Before planning or implementation, it would help to confirm:
+- should the override allow only an exact version or also ranges?
+- what precedence should it have over the project-declared value?
+- is CI-only divergence from the main repo runtime intended to be supported?
+
+Once that behavior is confirmed, the work can be scoped safely.
+
+## Promotion Notes
+
+- This reflection draft is derived from the run result and bounded context bundle.
+- Promote into `state/` only after the underlying evidence is reviewed and worth retaining.
+- Promote into `history/` only if the event is part of the public evolutionary trail.
+

--- a/state/targets/pnpm-pnpm.md
+++ b/state/targets/pnpm-pnpm.md
@@ -1,6 +1,6 @@
 ---
 title: Target Dossier — pnpm/pnpm
-updated: 2026-04-17
+updated: 2026-04-16
 visibility: public
 subject_kind: github_repository
 subject_locator: pnpm/pnpm
@@ -27,3 +27,7 @@ test of whether automaton can help strangers without drifting into noise.
 - prefer exact reproduction or config clarification over package-manager ideology
 - bounded docs and validation comments are higher trust than broad architecture takes
 - do not argue with maintainers about intended behavior when the docs already settle it
+
+## Recent Outcomes
+
+- 2026-04-16 · `issue-triage` · `success` · `rx_f995ec15a0814f5c92618a1bc7d7ac8b` · Feature request for pnpm 11 to allow an environment-variable override of the Node version managed through `devEngines.runtime`, mainly for CI jobs that still need an older Node version after `use-node-version` was removed.


### PR DESCRIPTION
## Summary

This draft PR updates operator memory from the `issue-triage` lane.

- Appends the new reflection/history drafts into repo-owned surfaces
- Updates the target dossier recent-outcomes projection
- Keeps canonical evidence in workflow receipts and artifacts

<!-- automaton:generated-pr-policy lane=issue-triage merge=human_review draft_only=true -->
## Generated PR Policy

- Generated by lane: `issue-triage`
- Publication mode: `draft-only` until a human intentionally promotes the PR
- Merge policy: `human-reviewed` only; no autonomous merge is allowed
- Correction policy: use the `rollback` lane or a corrective PR/comment when this output is wrong
- Receipts: inspect the linked workflow artifacts before review or merge