### PR TITLE
[runx] update issue-triage operator memory

### DIFF
--- a/history/2026-04-16-issue-triage-nilstate-automaton-pr-27-lane-finished-with-success.md
+++ b/history/2026-04-16-issue-triage-nilstate-automaton-pr-27-lane-finished-with-success.md
@@ -1,0 +1,23 @@
+---
+title: Issue Triage — lane finished with success
+date: 2026-04-16
+visibility: public
+lane: issue-triage
+status: success
+feed_channel: main
+main_feed_eligible: true
+subject_kind: github_pull_request
+subject_locator: nilstate/automaton#pr/27
+target_repo: nilstate/automaton
+pr_number: 27
+receipt_id: rx_b2bc5df0ace04d31940a3290ae0cae61
+---
+
+# Issue Triage — lane finished with success
+
+A `issue-triage` run against `nilstate/automaton#pr/27` finished with `success`.
+
+Summary: lane finished with success
+
+Receipt reference: `rx_b2bc5df0ace04d31940a3290ae0cae61`.
+

--- a/reflections/2026-04-16-issue-triage-nilstate-automaton-pr-27-lane-finished-with-success.md
+++ b/reflections/2026-04-16-issue-triage-nilstate-automaton-pr-27-lane-finished-with-success.md
@@ -1,0 +1,34 @@
+---
+title: Issue Triage — lane finished with success
+date: 2026-04-16
+visibility: public
+lane: issue-triage
+status: success
+feed_channel: main
+main_feed_eligible: true
+receipt_id: rx_b2bc5df0ace04d31940a3290ae0cae61
+subject_kind: github_pull_request
+subject_locator: nilstate/automaton#pr/27
+target_repo: nilstate/automaton
+pr_number: 27
+---
+
+# Issue Triage — lane finished with success
+
+## What Happened
+
+- Lane: `issue-triage`
+- Subject: `nilstate/automaton#pr/27`
+- Status: `success`
+- Receipt: `rx_b2bc5df0ace04d31940a3290ae0cae61`
+
+## Signals
+
+- Summary: lane finished with success
+
+## Promotion Notes
+
+- This reflection draft is derived from the run result and bounded context bundle.
+- Promote into `state/` only after the underlying evidence is reviewed and worth retaining.
+- Promote into `history/` only if the event is part of the public evolutionary trail.
+

--- a/state/targets/nilstate-automaton.md
+++ b/state/targets/nilstate-automaton.md
@@ -1,6 +1,6 @@
 ---
 title: Target Dossier — nilstate/automaton
-updated: 2026-04-17
+updated: 2026-04-16
 visibility: public
 subject_kind: github_repository
 subject_locator: nilstate/automaton
@@ -33,3 +33,7 @@ line.
 - repo-local changes are high-confidence when scoped cleanly
 - public narrative must remain subordinate to receipts and committed state
 - changes that alter workflow publication rules deserve extra care
+
+## Recent Outcomes
+
+- 2026-04-16 · `issue-triage` · `success` · `rx_b2bc5df0ace04d31940a3290ae0cae61` · lane finished with success


### PR DESCRIPTION
## Summary

This draft PR updates operator memory from the `issue-triage` lane.

- Appends the new reflection/history drafts into repo-owned surfaces
- Updates the target dossier recent-outcomes projection
- Keeps canonical evidence in workflow receipts and artifacts

<!-- automaton:generated-pr-policy lane=issue-triage merge=human_review draft_only=true -->
## Generated PR Policy

- Generated by lane: `issue-triage`
- Publication mode: `draft-only` until a human intentionally promotes the PR
- Merge policy: `human-reviewed` only; no autonomous merge is allowed
- Correction policy: use the `rollback` lane or a corrective PR/comment when this output is wrong
- Receipts: inspect the linked workflow artifacts before review or merge