### PR TITLE
[runx] update issue-triage operator memory

### DIFF
--- a/history/2026-04-20-issue-triage-nilstate-aster-pr-71-lane-finished-with-success.md
+++ b/history/2026-04-20-issue-triage-nilstate-aster-pr-71-lane-finished-with-success.md
@@ -1,0 +1,27 @@
+---
+title: Issue Triage — lane finished with success
+date: 2026-04-20
+visibility: public
+lane: issue-triage
+status: success
+feed_channel: main
+main_feed_eligible: true
+subject_kind: github_pull_request
+subject_locator: nilstate/aster#pr/71
+target_repo: nilstate/aster
+pr_number: 71
+receipt_id: rx_7d62aa798ff64bad9301c91625cabcf4
+---
+
+# Issue Triage — lane finished with success
+
+A `issue-triage` run against `nilstate/aster#pr/71` finished with `success`.
+
+Summary: lane finished with success
+
+Receipt reference: `rx_7d62aa798ff64bad9301c91625cabcf4`.
+
+## Approval Context
+
+- Approval guidance narrows the run; it does not widen authority beyond lane policy.
+

--- a/reflections/2026-04-20-issue-triage-nilstate-aster-pr-71-lane-finished-with-success.md
+++ b/reflections/2026-04-20-issue-triage-nilstate-aster-pr-71-lane-finished-with-success.md
@@ -1,0 +1,38 @@
+---
+title: Issue Triage — lane finished with success
+date: 2026-04-20
+visibility: public
+lane: issue-triage
+status: success
+feed_channel: main
+main_feed_eligible: true
+receipt_id: rx_7d62aa798ff64bad9301c91625cabcf4
+subject_kind: github_pull_request
+subject_locator: nilstate/aster#pr/71
+target_repo: nilstate/aster
+pr_number: 71
+---
+
+# Issue Triage — lane finished with success
+
+## What Happened
+
+- Lane: `issue-triage`
+- Subject: `nilstate/aster#pr/71`
+- Status: `success`
+- Receipt: `rx_7d62aa798ff64bad9301c91625cabcf4`
+
+## Approval Context
+
+- Approval guidance narrows the run; it does not widen authority beyond lane policy.
+
+## Signals
+
+- Summary: lane finished with success
+
+## Promotion Notes
+
+- This reflection draft is derived from the run result and bounded context bundle.
+- Promote into `state/` only after the underlying evidence is reviewed and worth retaining.
+- Promote into `history/` only if the event is part of the public evolutionary trail.
+

--- a/state/targets/nilstate-aster.md
+++ b/state/targets/nilstate-aster.md
@@ -1,6 +1,6 @@
 ---
 title: Target Dossier — nilstate/aster
-updated: 2026-04-17
+updated: 2026-04-20
 visibility: public
 subject_kind: github_repository
 subject_locator: nilstate/aster
@@ -35,3 +35,7 @@ line.
 - repo-local changes are high-confidence when scoped cleanly
 - public narrative must remain subordinate to receipts and committed state
 - changes that alter workflow publication rules deserve extra care
+
+## Recent Outcomes
+
+- 2026-04-20 · `issue-triage` · `success` · `rx_7d62aa798ff64bad9301c91625cabcf4` · lane finished with success


### PR DESCRIPTION
## Summary

This draft PR updates operator memory from the `issue-triage` lane.

- Appends the new reflection/history drafts into repo-owned surfaces
- Updates the target dossier recent-outcomes projection
- Receipts uploaded with this workflow run remain the canonical evidence

<!-- aster:generated-pr-policy lane=issue-triage merge=human_review draft_only=true -->
## Generated PR Policy

- Generated by lane: `issue-triage`
- Publication mode: `draft-only` until a human intentionally promotes the PR
- Merge policy: `human-reviewed` only; no autonomous merge is allowed
- Correction policy: use the `rollback` workflow or a corrective PR/comment when this output is wrong
- Receipts: inspect the linked workflow artifacts before review or merge

## Change Surface Policy

- Repo scope: `aster` parity enforced
- Policy status: `allowed`
- Surfaces touched: `learned_state`, `public_history`, `reflections`