### PR TITLE
fix(issue): allow runxhq issue-triage targets

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -179,7 +179,7 @@ jobs:
         run: |
           TARGET_REPO="${{ steps.issue.outputs.target_repo }}"
           TARGET_SLUG="$(printf '%s' "${{ steps.issue.outputs.target_repo }}" | tr '[:upper:]/' '[:lower:]-')"
-          if ! printf '%s' "$TARGET_REPO" | grep -Eq '^nilstate/[A-Za-z0-9._-]+$'; then
+          if ! printf '%s' "$TARGET_REPO" | grep -Eq '^runxhq/[A-Za-z0-9._-]+$'; then
             echo "allowed=false" >> "$GITHUB_OUTPUT"
             echo "reason=target_outside_prerelease_v1_scope" >> "$GITHUB_OUTPUT"
             echo "Target repo '$TARGET_REPO' is outside prerelease v1 scope; skipping issue-triage." >> "$GITHUB_STEP_SUMMARY"
@@ -498,7 +498,7 @@ jobs:
         run: |
           TARGET_REPO="${{ github.event.inputs.target_repo || github.repository }}"
           TARGET_SLUG="$(printf '%s' "$TARGET_REPO" | tr '[:upper:]/' '[:lower:]-')"
-          if ! printf '%s' "$TARGET_REPO" | grep -Eq '^nilstate/[A-Za-z0-9._-]+$'; then
+          if ! printf '%s' "$TARGET_REPO" | grep -Eq '^runxhq/[A-Za-z0-9._-]+$'; then
             echo "allowed=false" >> "$GITHUB_OUTPUT"
             echo "reason=target_outside_prerelease_v1_scope" >> "$GITHUB_OUTPUT"
             echo "Target repo '$TARGET_REPO' is outside prerelease v1 scope; skipping issue-triage." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- update issue-triage target scope to canonical `runxhq/*`
- keep prerelease scope bounded while matching the curated target dossiers: `runxhq-aster` and `runxhq-runx`

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/issue-triage.yml'); puts 'yaml ok'"`
- `npm run check`
- `git diff --check`