### PR TITLE
fix(proving-ground): use local runx evolve skill

### DIFF
--- a/scripts/proving-ground.sh
+++ b/scripts/proving-ground.sh
@@ -34,16 +34,17 @@ run_json() {
 
   local receipt_dir="$ARTIFACT_DIR/${name}-receipts"
   local output_path="$ARTIFACT_DIR/${name}.json"
-  local -a answers_args=()
+  local -a run_args
+  run_args=("$@")
 
   mkdir -p "$receipt_dir"
 
   if [[ -n "$RUNX_ANSWERS_DIR" && -f "$RUNX_ANSWERS_DIR/${name}.json" ]]; then
-    answers_args=(--answers "$RUNX_ANSWERS_DIR/${name}.json")
+    run_args+=(--answers "$RUNX_ANSWERS_DIR/${name}.json")
   fi
 
   set +e
-  node "$CLI_BIN" "$@" "${answers_args[@]}" --non-interactive --json --receipt-dir "$receipt_dir" >"$output_path"
+  node "$CLI_BIN" "${run_args[@]}" --non-interactive --json --receipt-dir "$receipt_dir" >"$output_path"
   local exit_code=$?
   set -e
 
@@ -55,7 +56,8 @@ run_json() {
 }
 
 run_json evolve-introspect \
-  evolve \
+  skill "$SKILLS_ROOT/evolve" \
+  --runner introspect \
   --repo_root "$ASTER_ROOT"
 
 run_json sourcey \


### PR DESCRIPTION
## Summary

- invoke the checked-out runx `evolve` skill by local path in proving-ground
- assemble optional answers arguments without tripping `set -u` when no answer file is present

## Validation

- `RUNX_ROOT=/Users/kam/dev/runx-oss-thread-story ASTER_ROOT=/Users/kam/dev/runx/aster ARTIFACT_DIR=/tmp/aster-proving-ground-test PROVING_GROUND_PROFILE=minimal bash scripts/proving-ground.sh`
  - This runs with no `$RUNX_ANSWERS_DIR`, so it directly exercises the no-answer-file branch that previously tripped `set -u`.
- `node scripts/summarize-proving-ground.mjs /tmp/aster-proving-ground-test`
- `npm run check`
- `git diff --check`
- `bash -n scripts/proving-ground.sh`