### PR TITLE
chore(ci): bump runx oss pin to ec8e16af1e69

### DIFF
--- a/state/runx-oss-pin.json
+++ b/state/runx-oss-pin.json
@@ -1,8 +1,8 @@
 {
   "schema": "runx.aster_runx_oss_pin.v1",
   "repository": "runxhq/runx",
-  "ref": "f5c7f8192605f4b1ec49437ab2df331ca0d0b9cc",
-  "expected_head": "f5c7f8192605f4b1ec49437ab2df331ca0d0b9cc",
+  "ref": "ec8e16af1e69af61f6686cb55e46b47b9b507262",
+  "expected_head": "ec8e16af1e69af61f6686cb55e46b47b9b507262",
   "parent_workspace_commit": "80e76ffdf8de9d619c17b18e9cfc73f94aad9369",
-  "note": "Advanced to runxhq/runx main HEAD (green ci.yml, 2026-06-05) so the pinned runtime matches latest scafld for the dogfood lanes. parent_workspace_commit retained from the prior cutover baseline."
+  "note": "Auto-bumped to runxhq/runx main HEAD ec8e16af1e69af61f6686cb55e46b47b9b507262 (latest green ci.yml)."
 }


### PR DESCRIPTION
Automated bump of the runx OSS pin to the latest green `runxhq/runx` main commit (`ec8e16af1e69af61f6686cb55e46b47b9b507262`). Pre-bump smoke built the runtime at the candidate SHA and confirmed `runx --version`.